### PR TITLE
Pin third-party actions to SHAs, bump to current majors, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/*"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 7

--- a/idl-upload/action.yaml
+++ b/idl-upload/action.yaml
@@ -23,7 +23,7 @@ runs:
         DEPLOY_KEYPAIR: ${{ inputs.keypair }}
 
     - name: Upload IDL
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 50

--- a/idl-upload/action.yaml
+++ b/idl-upload/action.yaml
@@ -23,7 +23,7 @@ runs:
         DEPLOY_KEYPAIR: ${{ inputs.keypair }}
 
     - name: Upload IDL
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 50

--- a/metadata-upload/action.yaml
+++ b/metadata-upload/action.yaml
@@ -45,7 +45,7 @@ runs:
         DEPLOY_KEYPAIR: ${{ inputs.keypair }}
 
     - name: Upload metadata
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 50

--- a/metadata-upload/action.yaml
+++ b/metadata-upload/action.yaml
@@ -45,7 +45,7 @@ runs:
         DEPLOY_KEYPAIR: ${{ inputs.keypair }}
 
     - name: Upload metadata
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 50

--- a/program-upgrade/action.yaml
+++ b/program-upgrade/action.yaml
@@ -67,7 +67,7 @@ runs:
 
     - name: Deploy new program
       if: steps.check-program.outputs.exists == 'false'
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -83,7 +83,7 @@ runs:
 
     - name: Upgrade existing program
       if: steps.check-program.outputs.exists == 'true'
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 3

--- a/program-upgrade/action.yaml
+++ b/program-upgrade/action.yaml
@@ -67,7 +67,7 @@ runs:
 
     - name: Deploy new program
       if: steps.check-program.outputs.exists == 'false'
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -83,7 +83,7 @@ runs:
 
     - name: Upgrade existing program
       if: steps.check-program.outputs.exists == 'true'
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 3

--- a/run-tests/action.yaml
+++ b/run-tests/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache node_modules
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ./node_modules/
         key: node-modules-${{ runner.os }}-build-v0.1-${{ inputs.anchor_version }}-${{ inputs.solana_version }}
@@ -30,7 +30,7 @@ runs:
       run: yarn install
 
     - name: Cache Cargo dependencies
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         cache-directories: |
           ~/.cargo/registry/index/

--- a/run-tests/action.yaml
+++ b/run-tests/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache node_modules
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       with:
         path: ./node_modules/
         key: node-modules-${{ runner.os }}-build-v0.1-${{ inputs.anchor_version }}-${{ inputs.solana_version }}
@@ -30,7 +30,7 @@ runs:
       run: yarn install
 
     - name: Cache Cargo dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         cache-directories: |
           ~/.cargo/registry/index/

--- a/setup-all/action.yaml
+++ b/setup-all/action.yaml
@@ -29,7 +29,7 @@ runs:
     - run: git submodule update --init --recursive --depth 1
       shell: bash
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: inputs.solana_version != ''
       name: Cache Solana Tool Suite
       id: cache-solana
@@ -95,7 +95,7 @@ runs:
         echo "Cache key being used: anchor-cli-${{ runner.os }}-v0003-$VERSION"
         echo "========================="
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: inputs.anchor_version != ''
       name: Cache Anchor Cli
       id: cache-anchor-cli
@@ -130,7 +130,7 @@ runs:
         echo "Cache key being used: solana-verify-${{ runner.os }}-v0001-${{ inputs.verify_version }}"
         echo "========================="
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: inputs.verify_version != ''
       name: Cache Solana Verify
       id: cache-solana-verify
@@ -149,12 +149,12 @@ runs:
       shell: bash
       run: solana-verify --version
 
-    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       if: inputs.node_version != ''
       with:
         node-version: ${{ inputs.node_version }}
 
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       name: Cache Toml Cli
       id: cache-toml-cli
       with:

--- a/setup-all/action.yaml
+++ b/setup-all/action.yaml
@@ -29,7 +29,7 @@ runs:
     - run: git submodule update --init --recursive --depth 1
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: inputs.solana_version != ''
       name: Cache Solana Tool Suite
       id: cache-solana
@@ -95,7 +95,7 @@ runs:
         echo "Cache key being used: anchor-cli-${{ runner.os }}-v0003-$VERSION"
         echo "========================="
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: inputs.anchor_version != ''
       name: Cache Anchor Cli
       id: cache-anchor-cli
@@ -130,7 +130,7 @@ runs:
         echo "Cache key being used: solana-verify-${{ runner.os }}-v0001-${{ inputs.verify_version }}"
         echo "========================="
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: inputs.verify_version != ''
       name: Cache Solana Verify
       id: cache-solana-verify
@@ -149,12 +149,12 @@ runs:
       shell: bash
       run: solana-verify --version
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       if: inputs.node_version != ''
       with:
         node-version: ${{ inputs.node_version }}
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       name: Cache Toml Cli
       id: cache-toml-cli
       with:

--- a/write-idl-buffer/action.yaml
+++ b/write-idl-buffer/action.yaml
@@ -44,7 +44,7 @@ runs:
     - name: Write IDL buffer
       id: write-buffer
       if: steps.check-idl.outputs.exists == 'true'
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -75,7 +75,7 @@ runs:
 
     - name: Set Buffer Authority
       if: steps.write-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -91,7 +91,7 @@ runs:
 
     - name: Set Program IDL Authority
       if: steps.write-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 5
         max_attempts: 3

--- a/write-idl-buffer/action.yaml
+++ b/write-idl-buffer/action.yaml
@@ -44,7 +44,7 @@ runs:
     - name: Write IDL buffer
       id: write-buffer
       if: steps.check-idl.outputs.exists == 'true'
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -75,7 +75,7 @@ runs:
 
     - name: Set Buffer Authority
       if: steps.write-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -91,7 +91,7 @@ runs:
 
     - name: Set Program IDL Authority
       if: steps.write-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 5
         max_attempts: 3

--- a/write-metadata-buffer/action.yaml
+++ b/write-metadata-buffer/action.yaml
@@ -34,7 +34,7 @@ runs:
 
     - name: Create metadata buffer
       id: create-buffer
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -61,7 +61,7 @@ runs:
 
     - name: Transfer buffer authority
       if: steps.create-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 5
         max_attempts: 3

--- a/write-metadata-buffer/action.yaml
+++ b/write-metadata-buffer/action.yaml
@@ -34,7 +34,7 @@ runs:
 
     - name: Create metadata buffer
       id: create-buffer
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 3
@@ -61,7 +61,7 @@ runs:
 
     - name: Transfer buffer authority
       if: steps.create-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 5
         max_attempts: 3

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -88,7 +88,7 @@ runs:
 
     - name: Write program buffer
       id: write-buffer
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 60
         max_attempts: 3
@@ -128,7 +128,7 @@ runs:
     # If the deploy fails you can also close the buffer with the multisig using the cli command squad-closebuffer
     - name: Transfer buffer authority
       if: steps.check-program.outputs.exists == 'true'
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
       with:
         timeout_minutes: 10
         max_attempts: 50

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -88,7 +88,7 @@ runs:
 
     - name: Write program buffer
       id: write-buffer
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 60
         max_attempts: 3
@@ -128,7 +128,7 @@ runs:
     # If the deploy fails you can also close the buffer with the multisig using the cli command squad-closebuffer
     - name: Transfer buffer authority
       if: steps.check-program.outputs.exists == 'true'
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 50


### PR DESCRIPTION
## Summary

- **Pin all third-party `uses:` references to immutable commit SHAs** with a trailing `# vX.Y.Z` comment. This is the GitHub-recommended hardening for actions in third-party repos — a compromised or hijacked tag can no longer silently inject code into consumers of these composite actions.
- **Bump pinned actions to current major versions**:
  - `actions/cache`: v3/v4 → v5.0.5
  - `actions/setup-node`: v3 → v6.4.0
  - `nick-fields/retry`: v2 → v4.0.0
  - `Swatinem/rust-cache`: rolling v2 → v2.9.1
- **Add `.github/dependabot.yml`** with the GitHub Actions ecosystem and a release cooldown so new versions get time to settle before a bump PR is opened (30 days for majors, 7 for minor/patch).

The `directories` entry uses `/` and `/*` so Dependabot picks up the `action.yaml` files in each composite-action subdirectory at the repo root. Dependabot should automatically update the hashes on releases (along with the comment specifying the pinned versions).

Closes #10 