### PR TITLE
feat: add buffer-only squads release action

### DIFF
--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -102,7 +102,7 @@ runs:
     - name: Write metadata buffer
       id: write-metadata-buffer
       if: inputs.metadata-path != ''
-      uses: solana-developers/github-actions/write-metadata-buffer@15e43c56b2ad2047dde732d807082570de2b8486
+      uses: dev-jodee/github-actions/write-metadata-buffer@feat/prepare-squads-release-buffer
       with:
         idl-path: ${{ inputs.metadata-path }}
         rpc-url: ${{ inputs.rpc-url }}

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -36,10 +36,6 @@ inputs:
     description: "Git commit hash to verify against"
     required: false
     default: ""
-  mount-path:
-    description: "Path to the program directory for solana-verify PDA export"
-    required: false
-    default: ""
 
 outputs:
   buffer:
@@ -50,7 +46,7 @@ outputs:
     value: ${{ steps.write-metadata-buffer.outputs.buffer }}
   pda-tx:
     description: "Base64-encoded verify PDA transaction"
-    value: ${{ steps.export-verify-pda.outputs.tx }}
+    value: ${{ steps.export-verify-pda.outputs.pda_tx }}
 
 runs:
   using: "composite"
@@ -60,6 +56,10 @@ runs:
       run: |
         if [ "${{ inputs.export-verify-pda }}" = "true" ] && [ -z "${{ inputs.repo-url }}" ]; then
           echo "Error: repo-url is required when export-verify-pda is true"
+          exit 1
+        fi
+        if [ "${{ inputs.export-verify-pda }}" = "true" ] && [ -z "${{ inputs.commit-hash }}" ]; then
+          echo "Error: commit-hash is required when export-verify-pda is true"
           exit 1
         fi
 
@@ -88,36 +88,17 @@ runs:
     - name: Export verify PDA transaction
       id: export-verify-pda
       if: inputs.export-verify-pda == 'true'
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        ARGS=""
-
-        if [ -n "${{ inputs.mount-path }}" ]; then
-          ARGS="$ARGS --mount-path ${{ inputs.mount-path }}"
-        fi
-
-        if [ -n "${{ inputs.commit-hash }}" ]; then
-          ARGS="$ARGS --commit-hash ${{ inputs.commit-hash }}"
-        fi
-
-        TX=$(solana-verify export-pda-tx \
-          ${{ inputs.repo-url }} \
-          --program-id ${{ inputs.program-id }} \
-          --uploader ${{ inputs.squads-vault }} \
-          --url ${{ inputs.rpc-url }} \
-          --library-name ${{ inputs.program }} \
-          --encoding base64 \
-          $ARGS | tail -n 1)
-
-        if [ -z "$TX" ] || [[ ! "$TX" =~ ^[A-Za-z0-9+/=]+$ ]]; then
-          echo "Error: Invalid base64 transaction"
-          echo "Got: $TX"
-          exit 1
-        fi
-
-        echo "tx=$TX" >> $GITHUB_OUTPUT
+      uses: solana-developers/github-actions/verify-build@15e43c56b2ad2047dde732d807082570de2b8486
+      with:
+        program-id: ${{ inputs.program-id }}
+        program: ${{ inputs.program }}
+        rpc-url: ${{ inputs.rpc-url }}
+        keypair: ${{ inputs.keypair }}
+        repo-url: ${{ inputs.repo-url }}
+        commit-hash: ${{ inputs.commit-hash }}
+        network: "mainnet"
+        use-squads: "true"
+        vault-address: ${{ inputs.squads-vault }}
 
     - name: Write summary
       shell: bash

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -81,7 +81,7 @@ runs:
 
     - name: Write program buffer
       id: write-program-buffer
-      uses: solana-developers/github-actions/write-program-buffer@15e43c56b2ad2047dde732d807082570de2b8486
+      uses: dev-jodee/github-actions/write-program-buffer@feat/prepare-squads-release-buffer
       with:
         program-id: ${{ inputs.program-id }}
         program: ${{ inputs.program }}

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -40,6 +40,10 @@ inputs:
     description: "Maximum program buffer write attempts"
     required: false
     default: "1"
+  program-buffer-use-rpc:
+    description: "Send program buffer write transactions through the configured RPC instead of validator TPUs"
+    required: false
+    default: "false"
   export-verify-pda:
     description: "Export a solana-verify PDA transaction for the Squads vault"
     required: false
@@ -93,6 +97,7 @@ runs:
         write-timeout-minutes: ${{ inputs.program-buffer-write-timeout-minutes }}
         retry-timeout-minutes: ${{ inputs.program-buffer-retry-timeout-minutes }}
         retry-attempts: ${{ inputs.program-buffer-retry-attempts }}
+        use-rpc: ${{ inputs.program-buffer-use-rpc }}
 
     - name: Write metadata buffer
       id: write-metadata-buffer

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -59,12 +59,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Write keypair
-      shell: bash
-      run: echo "$DEPLOY_KEYPAIR" > ./deploy-keypair.json && chmod 600 ./deploy-keypair.json
-      env:
-        DEPLOY_KEYPAIR: ${{ inputs.keypair }}
-
     - name: Validate inputs
       shell: bash
       run: |
@@ -73,148 +67,47 @@ runs:
           exit 1
         fi
 
-    - name: Get current program size if it exists
-      id: check-program
+    - name: Link reusable actions
       shell: bash
       run: |
-        set +e
+        set -euo pipefail
 
-        echo "Checking program info..."
-        PROGRAM_INFO=$(solana program show ${{ inputs.program-id }} -u ${{ inputs.rpc-url }} 2>&1)
-        EXIT_CODE=$?
-        echo "Raw program info output:"
-        echo "$PROGRAM_INFO"
+        ACTION_ROOT=$(cd "$ACTION_PATH/.." && pwd)
+        LINK_PATH=".github-actions/solana-developers-github-actions"
 
-        if [ $EXIT_CODE -eq 0 ]; then
-          echo "exists=true" >> $GITHUB_OUTPUT
-          CURRENT_SIZE=$(echo "$PROGRAM_INFO" | grep "Data Length:" | sed -E 's/.*Data Length: ([0-9]+).*/\1/' | cut -d ' ' -f1)
-          echo "Current program data length: $CURRENT_SIZE"
-          echo "data_len=$CURRENT_SIZE" >> $GITHUB_OUTPUT
-        else
-          if echo "$PROGRAM_INFO" | grep -q "Unable to find the account"; then
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Program does not exist yet, skipping size check"
-          else
-            echo "Error checking program: $PROGRAM_INFO"
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
+        mkdir -p "$(dirname "$LINK_PATH")"
+        if [ -e "$LINK_PATH" ] && [ ! -L "$LINK_PATH" ]; then
+          echo "Error: $LINK_PATH already exists and is not a symlink"
+          exit 1
         fi
 
-        set -e
-
-    - name: Resize program if needed
-      if: inputs.extend-program == 'true' && steps.check-program.outputs.exists == 'true'
-      shell: bash
-      run: |
-        REQUIRED_SIZE=$(wc -c < ./target/deploy/${{ inputs.program }}.so)
-        CURRENT_SIZE="${{ steps.check-program.outputs.data_len }}"
-        echo "Required size: $REQUIRED_SIZE"
-        echo "Current size: $CURRENT_SIZE"
-
-        if [ "$REQUIRED_SIZE" -gt "$CURRENT_SIZE" ]; then
-          EXTEND_SIZE=$((REQUIRED_SIZE - CURRENT_SIZE))
-          echo "Program needs to be extended by $EXTEND_SIZE bytes"
-          solana program extend ${{ inputs.program-id }} $EXTEND_SIZE \
-            --keypair ./deploy-keypair.json \
-            --url ${{ inputs.rpc-url }} \
-            --commitment confirmed
-        else
-          echo "Program size is sufficient"
-        fi
+        ln -sfn "$ACTION_ROOT" "$LINK_PATH"
+      env:
+        ACTION_PATH: ${{ github.action_path }}
 
     - name: Write program buffer
       id: write-program-buffer
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github-actions/solana-developers-github-actions/write-program-buffer
       with:
-        timeout_minutes: 60
-        max_attempts: 3
-        shell: bash
-        command: |
-          echo "Creating program buffer... (Attempt $RETRY_ATTEMPT of 3)"
-          OUTPUT=$(solana program write-buffer \
-            ./target/deploy/${{ inputs.program }}.so \
-            --url ${{ inputs.rpc-url }} \
-            --keypair ./deploy-keypair.json \
-            --max-sign-attempts 100 \
-            --with-compute-unit-price ${{ inputs.priority-fee }} \
-            --use-rpc \
-            2>&1)
-
-          echo "$OUTPUT"
-
-          if ! echo "$OUTPUT" | grep -q "Buffer:"; then
-            echo "Error: Buffer creation failed"
-            exit 1
-          fi
-
-          BUFFER=$(echo "$OUTPUT" | grep "Buffer:" | cut -d " " -f2)
-          if [ -z "$BUFFER" ]; then
-            echo "Error: Could not extract buffer address"
-            exit 1
-          fi
-
-          echo "Found buffer: $BUFFER"
-          echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
-
-    - name: Transfer program buffer authority
-      if: steps.write-program-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-      with:
-        timeout_minutes: 10
-        max_attempts: 50
-        shell: bash
-        command: |
-          BUFFER="${{ steps.write-program-buffer.outputs.buffer }}"
-          echo "Transferring program buffer authority for $BUFFER to ${{ inputs.squads-vault }}"
-          solana program set-buffer-authority $BUFFER \
-            --keypair ./deploy-keypair.json \
-            --new-buffer-authority ${{ inputs.squads-vault }} \
-            --url ${{ inputs.rpc-url }}
+        program-id: ${{ inputs.program-id }}
+        program: ${{ inputs.program }}
+        rpc-url: ${{ inputs.rpc-url }}
+        keypair: ${{ inputs.keypair }}
+        buffer-authority-address: ${{ inputs.squads-vault }}
+        priority-fee: ${{ inputs.priority-fee }}
+        extend-program: ${{ inputs.extend-program }}
+        transfer-authority-on-new-program: "true"
 
     - name: Write metadata buffer
       id: write-metadata-buffer
       if: inputs.metadata-path != ''
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github-actions/solana-developers-github-actions/write-metadata-buffer
       with:
-        timeout_minutes: 10
-        max_attempts: 3
-        shell: bash
-        command: |
-          echo "Creating program-metadata buffer from ${{ inputs.metadata-path }}..."
-
-          OUTPUT=$(NO_COLOR=1 npx @solana-program/program-metadata@0.5.1 create-buffer \
-            "${{ inputs.metadata-path }}" \
-            --keypair ./deploy-keypair.json \
-            --rpc "${{ inputs.rpc-url }}" \
-            --priority-fees ${{ inputs.priority-fee }} 2>&1)
-
-          echo "$OUTPUT"
-
-          BUFFER=$(echo "$OUTPUT" | grep -i "buffer:" | head -1 | grep -oE '[1-9A-HJ-NP-Za-km-z]{32,44}')
-          if [ -z "$BUFFER" ]; then
-            echo "Error: Could not extract metadata buffer address"
-            exit 1
-          fi
-
-          echo "Found metadata buffer: $BUFFER"
-          echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
-
-    - name: Transfer metadata buffer authority
-      if: steps.write-metadata-buffer.outputs.buffer != ''
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-      with:
-        timeout_minutes: 5
-        max_attempts: 3
-        shell: bash
-        command: |
-          BUFFER="${{ steps.write-metadata-buffer.outputs.buffer }}"
-          echo "Transferring metadata buffer authority for $BUFFER to ${{ inputs.squads-vault }}"
-
-          NO_COLOR=1 npx @solana-program/program-metadata@0.5.1 set-buffer-authority "$BUFFER" \
-            --new-authority ${{ inputs.squads-vault }} \
-            --keypair ./deploy-keypair.json \
-            --rpc "${{ inputs.rpc-url }}" \
-            --priority-fees ${{ inputs.priority-fee }}
+        idl-path: ${{ inputs.metadata-path }}
+        rpc-url: ${{ inputs.rpc-url }}
+        keypair: ${{ inputs.keypair }}
+        buffer-authority: ${{ inputs.squads-vault }}
+        priority-fees: ${{ inputs.priority-fee }}
 
     - name: Export verify PDA transaction
       id: export-verify-pda
@@ -266,8 +159,3 @@ runs:
         echo "- Buffer authority: \`${{ inputs.squads-vault }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Create the program upgrade from Squads using the buffer above. This action does not create a Squads proposal." >> $GITHUB_STEP_SUMMARY
-
-    - name: Cleanup
-      if: always()
-      shell: bash
-      run: rm -f ./deploy-keypair.json

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -1,0 +1,273 @@
+name: "Prepare Squads Release"
+description: "Creates Solana release buffers and assigns their authority to a Squads vault without creating a Squads proposal"
+inputs:
+  program-id:
+    description: "Program ID to upgrade"
+    required: true
+  program:
+    description: "Program name"
+    required: true
+  rpc-url:
+    description: "Solana RPC URL"
+    required: true
+  keypair:
+    description: "Payer keypair used for buffer preparation. It does not need to be a Squads member."
+    required: true
+  squads-vault:
+    description: "Squads vault address to set as buffer authority"
+    required: true
+  metadata-path:
+    description: "Optional IDL or metadata JSON path for a program-metadata buffer"
+    required: false
+    default: ""
+  priority-fee:
+    description: "Priority fee in microlamports"
+    required: false
+    default: "100000"
+  export-verify-pda:
+    description: "Export a solana-verify PDA transaction for the Squads vault"
+    required: false
+    default: "false"
+  repo-url:
+    description: "GitHub repository URL for solana-verify PDA export"
+    required: false
+    default: ""
+  commit-hash:
+    description: "Git commit hash to verify against"
+    required: false
+    default: ""
+  mount-path:
+    description: "Path to the program directory for solana-verify PDA export"
+    required: false
+    default: ""
+  extend-program:
+    description: "Extend the program account before buffer creation if the new program is larger"
+    required: false
+    default: "true"
+
+outputs:
+  buffer:
+    description: "Created program buffer address"
+    value: ${{ steps.write-program-buffer.outputs.buffer }}
+  metadata-buffer:
+    description: "Created program-metadata buffer address"
+    value: ${{ steps.write-metadata-buffer.outputs.buffer }}
+  pda-tx:
+    description: "Base64-encoded verify PDA transaction"
+    value: ${{ steps.export-verify-pda.outputs.tx }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Write keypair
+      shell: bash
+      run: echo "$DEPLOY_KEYPAIR" > ./deploy-keypair.json && chmod 600 ./deploy-keypair.json
+      env:
+        DEPLOY_KEYPAIR: ${{ inputs.keypair }}
+
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [ "${{ inputs.export-verify-pda }}" = "true" ] && [ -z "${{ inputs.repo-url }}" ]; then
+          echo "Error: repo-url is required when export-verify-pda is true"
+          exit 1
+        fi
+
+    - name: Get current program size if it exists
+      id: check-program
+      shell: bash
+      run: |
+        set +e
+
+        echo "Checking program info..."
+        PROGRAM_INFO=$(solana program show ${{ inputs.program-id }} -u ${{ inputs.rpc-url }} 2>&1)
+        EXIT_CODE=$?
+        echo "Raw program info output:"
+        echo "$PROGRAM_INFO"
+
+        if [ $EXIT_CODE -eq 0 ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+          CURRENT_SIZE=$(echo "$PROGRAM_INFO" | grep "Data Length:" | sed -E 's/.*Data Length: ([0-9]+).*/\1/' | cut -d ' ' -f1)
+          echo "Current program data length: $CURRENT_SIZE"
+          echo "data_len=$CURRENT_SIZE" >> $GITHUB_OUTPUT
+        else
+          if echo "$PROGRAM_INFO" | grep -q "Unable to find the account"; then
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Program does not exist yet, skipping size check"
+          else
+            echo "Error checking program: $PROGRAM_INFO"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        fi
+
+        set -e
+
+    - name: Resize program if needed
+      if: inputs.extend-program == 'true' && steps.check-program.outputs.exists == 'true'
+      shell: bash
+      run: |
+        REQUIRED_SIZE=$(wc -c < ./target/deploy/${{ inputs.program }}.so)
+        CURRENT_SIZE="${{ steps.check-program.outputs.data_len }}"
+        echo "Required size: $REQUIRED_SIZE"
+        echo "Current size: $CURRENT_SIZE"
+
+        if [ "$REQUIRED_SIZE" -gt "$CURRENT_SIZE" ]; then
+          EXTEND_SIZE=$((REQUIRED_SIZE - CURRENT_SIZE))
+          echo "Program needs to be extended by $EXTEND_SIZE bytes"
+          solana program extend ${{ inputs.program-id }} $EXTEND_SIZE \
+            --keypair ./deploy-keypair.json \
+            --url ${{ inputs.rpc-url }} \
+            --commitment confirmed
+        else
+          echo "Program size is sufficient"
+        fi
+
+    - name: Write program buffer
+      id: write-program-buffer
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        timeout_minutes: 60
+        max_attempts: 3
+        shell: bash
+        command: |
+          echo "Creating program buffer... (Attempt $RETRY_ATTEMPT of 3)"
+          OUTPUT=$(solana program write-buffer \
+            ./target/deploy/${{ inputs.program }}.so \
+            --url ${{ inputs.rpc-url }} \
+            --keypair ./deploy-keypair.json \
+            --max-sign-attempts 100 \
+            --with-compute-unit-price ${{ inputs.priority-fee }} \
+            --use-rpc \
+            2>&1)
+
+          echo "$OUTPUT"
+
+          if ! echo "$OUTPUT" | grep -q "Buffer:"; then
+            echo "Error: Buffer creation failed"
+            exit 1
+          fi
+
+          BUFFER=$(echo "$OUTPUT" | grep "Buffer:" | cut -d " " -f2)
+          if [ -z "$BUFFER" ]; then
+            echo "Error: Could not extract buffer address"
+            exit 1
+          fi
+
+          echo "Found buffer: $BUFFER"
+          echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
+
+    - name: Transfer program buffer authority
+      if: steps.write-program-buffer.outputs.buffer != ''
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        timeout_minutes: 10
+        max_attempts: 50
+        shell: bash
+        command: |
+          BUFFER="${{ steps.write-program-buffer.outputs.buffer }}"
+          echo "Transferring program buffer authority for $BUFFER to ${{ inputs.squads-vault }}"
+          solana program set-buffer-authority $BUFFER \
+            --keypair ./deploy-keypair.json \
+            --new-buffer-authority ${{ inputs.squads-vault }} \
+            --url ${{ inputs.rpc-url }}
+
+    - name: Write metadata buffer
+      id: write-metadata-buffer
+      if: inputs.metadata-path != ''
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        shell: bash
+        command: |
+          echo "Creating program-metadata buffer from ${{ inputs.metadata-path }}..."
+
+          OUTPUT=$(NO_COLOR=1 npx @solana-program/program-metadata@0.5.1 create-buffer \
+            "${{ inputs.metadata-path }}" \
+            --keypair ./deploy-keypair.json \
+            --rpc "${{ inputs.rpc-url }}" \
+            --priority-fees ${{ inputs.priority-fee }} 2>&1)
+
+          echo "$OUTPUT"
+
+          BUFFER=$(echo "$OUTPUT" | grep -i "buffer:" | head -1 | grep -oE '[1-9A-HJ-NP-Za-km-z]{32,44}')
+          if [ -z "$BUFFER" ]; then
+            echo "Error: Could not extract metadata buffer address"
+            exit 1
+          fi
+
+          echo "Found metadata buffer: $BUFFER"
+          echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
+
+    - name: Transfer metadata buffer authority
+      if: steps.write-metadata-buffer.outputs.buffer != ''
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        shell: bash
+        command: |
+          BUFFER="${{ steps.write-metadata-buffer.outputs.buffer }}"
+          echo "Transferring metadata buffer authority for $BUFFER to ${{ inputs.squads-vault }}"
+
+          NO_COLOR=1 npx @solana-program/program-metadata@0.5.1 set-buffer-authority "$BUFFER" \
+            --new-authority ${{ inputs.squads-vault }} \
+            --keypair ./deploy-keypair.json \
+            --rpc "${{ inputs.rpc-url }}" \
+            --priority-fees ${{ inputs.priority-fee }}
+
+    - name: Export verify PDA transaction
+      id: export-verify-pda
+      if: inputs.export-verify-pda == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ARGS=""
+
+        if [ -n "${{ inputs.mount-path }}" ]; then
+          ARGS="$ARGS --mount-path ${{ inputs.mount-path }}"
+        fi
+
+        if [ -n "${{ inputs.commit-hash }}" ]; then
+          ARGS="$ARGS --commit-hash ${{ inputs.commit-hash }}"
+        fi
+
+        TX=$(solana-verify export-pda-tx \
+          ${{ inputs.repo-url }} \
+          --program-id ${{ inputs.program-id }} \
+          --uploader ${{ inputs.squads-vault }} \
+          --url ${{ inputs.rpc-url }} \
+          --library-name ${{ inputs.program }} \
+          --encoding base64 \
+          $ARGS | tail -n 1)
+
+        if [ -z "$TX" ] || [[ ! "$TX" =~ ^[A-Za-z0-9+/=]+$ ]]; then
+          echo "Error: Invalid base64 transaction"
+          echo "Got: $TX"
+          exit 1
+        fi
+
+        echo "tx=$TX" >> $GITHUB_OUTPUT
+
+    - name: Write summary
+      shell: bash
+      run: |
+        echo "## Squads release buffers" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- Program: \`${{ inputs.program-id }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- Program buffer: \`${{ steps.write-program-buffer.outputs.buffer }}\`" >> $GITHUB_STEP_SUMMARY
+        if [ -n "${{ steps.write-metadata-buffer.outputs.buffer }}" ]; then
+          echo "- Metadata buffer: \`${{ steps.write-metadata-buffer.outputs.buffer }}\`" >> $GITHUB_STEP_SUMMARY
+        fi
+        if [ "${{ inputs.export-verify-pda }}" = "true" ]; then
+          echo "- Verify PDA transaction exported: \`true\`" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "- Buffer authority: \`${{ inputs.squads-vault }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Create the program upgrade from Squads using the buffer above. This action does not create a Squads proposal." >> $GITHUB_STEP_SUMMARY
+
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: rm -f ./deploy-keypair.json

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -67,27 +67,9 @@ runs:
           exit 1
         fi
 
-    - name: Link reusable actions
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        ACTION_ROOT=$(cd "$ACTION_PATH/.." && pwd)
-        LINK_PATH=".github-actions/solana-developers-github-actions"
-
-        mkdir -p "$(dirname "$LINK_PATH")"
-        if [ -e "$LINK_PATH" ] && [ ! -L "$LINK_PATH" ]; then
-          echo "Error: $LINK_PATH already exists and is not a symlink"
-          exit 1
-        fi
-
-        ln -sfn "$ACTION_ROOT" "$LINK_PATH"
-      env:
-        ACTION_PATH: ${{ github.action_path }}
-
     - name: Write program buffer
       id: write-program-buffer
-      uses: ./.github-actions/solana-developers-github-actions/write-program-buffer
+      uses: solana-developers/github-actions/write-program-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
       with:
         program-id: ${{ inputs.program-id }}
         program: ${{ inputs.program }}
@@ -101,7 +83,7 @@ runs:
     - name: Write metadata buffer
       id: write-metadata-buffer
       if: inputs.metadata-path != ''
-      uses: ./.github-actions/solana-developers-github-actions/write-metadata-buffer
+      uses: solana-developers/github-actions/write-metadata-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
       with:
         idl-path: ${{ inputs.metadata-path }}
         rpc-url: ${{ inputs.rpc-url }}

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -40,10 +40,6 @@ inputs:
     description: "Path to the program directory for solana-verify PDA export"
     required: false
     default: ""
-  extend-program:
-    description: "Extend the program account before buffer creation if the new program is larger"
-    required: false
-    default: "true"
 
 outputs:
   buffer:
@@ -69,7 +65,7 @@ runs:
 
     - name: Write program buffer
       id: write-program-buffer
-      uses: dev-jodee/github-actions/write-program-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
+      uses: solana-developers/github-actions/write-program-buffer@15e43c56b2ad2047dde732d807082570de2b8486
       with:
         program-id: ${{ inputs.program-id }}
         program: ${{ inputs.program }}
@@ -77,13 +73,11 @@ runs:
         keypair: ${{ inputs.keypair }}
         buffer-authority-address: ${{ inputs.squads-vault }}
         priority-fee: ${{ inputs.priority-fee }}
-        extend-program: ${{ inputs.extend-program }}
-        transfer-authority-on-new-program: "true"
 
     - name: Write metadata buffer
       id: write-metadata-buffer
       if: inputs.metadata-path != ''
-      uses: dev-jodee/github-actions/write-metadata-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
+      uses: solana-developers/github-actions/write-metadata-buffer@15e43c56b2ad2047dde732d807082570de2b8486
       with:
         idl-path: ${{ inputs.metadata-path }}
         rpc-url: ${{ inputs.rpc-url }}

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -85,7 +85,7 @@ runs:
 
     - name: Write program buffer
       id: write-program-buffer
-      uses: dev-jodee/github-actions/write-program-buffer@feat/prepare-squads-release-buffer
+      uses: solana-developers/github-actions/write-program-buffer@main
       with:
         program-id: ${{ inputs.program-id }}
         program: ${{ inputs.program }}
@@ -102,7 +102,7 @@ runs:
     - name: Write metadata buffer
       id: write-metadata-buffer
       if: inputs.metadata-path != ''
-      uses: dev-jodee/github-actions/write-metadata-buffer@feat/prepare-squads-release-buffer
+      uses: solana-developers/github-actions/write-metadata-buffer@main
       with:
         idl-path: ${{ inputs.metadata-path }}
         rpc-url: ${{ inputs.rpc-url }}

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -32,10 +32,6 @@ inputs:
     description: "Maximum minutes to let a single program buffer write run before printing diagnostics"
     required: false
     default: "55"
-  program-buffer-retry-timeout-minutes:
-    description: "Maximum minutes for each program buffer retry wrapper attempt"
-    required: false
-    default: "60"
   program-buffer-retry-attempts:
     description: "Maximum program buffer write attempts"
     required: false
@@ -95,7 +91,6 @@ runs:
         priority-fee: ${{ inputs.priority-fee }}
         max-sign-attempts: ${{ inputs.program-buffer-max-sign-attempts }}
         write-timeout-minutes: ${{ inputs.program-buffer-write-timeout-minutes }}
-        retry-timeout-minutes: ${{ inputs.program-buffer-retry-timeout-minutes }}
         retry-attempts: ${{ inputs.program-buffer-retry-attempts }}
         use-rpc: ${{ inputs.program-buffer-use-rpc }}
 

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -24,6 +24,22 @@ inputs:
     description: "Priority fee in microlamports"
     required: false
     default: "100000"
+  program-buffer-max-sign-attempts:
+    description: "Maximum Solana CLI signing attempts for the program buffer"
+    required: false
+    default: "100"
+  program-buffer-write-timeout-minutes:
+    description: "Maximum minutes to let a single program buffer write run before printing diagnostics"
+    required: false
+    default: "55"
+  program-buffer-retry-timeout-minutes:
+    description: "Maximum minutes for each program buffer retry wrapper attempt"
+    required: false
+    default: "60"
+  program-buffer-retry-attempts:
+    description: "Maximum program buffer write attempts"
+    required: false
+    default: "1"
   export-verify-pda:
     description: "Export a solana-verify PDA transaction for the Squads vault"
     required: false
@@ -73,6 +89,10 @@ runs:
         keypair: ${{ inputs.keypair }}
         buffer-authority-address: ${{ inputs.squads-vault }}
         priority-fee: ${{ inputs.priority-fee }}
+        max-sign-attempts: ${{ inputs.program-buffer-max-sign-attempts }}
+        write-timeout-minutes: ${{ inputs.program-buffer-write-timeout-minutes }}
+        retry-timeout-minutes: ${{ inputs.program-buffer-retry-timeout-minutes }}
+        retry-attempts: ${{ inputs.program-buffer-retry-attempts }}
 
     - name: Write metadata buffer
       id: write-metadata-buffer

--- a/prepare-squads-release/action.yaml
+++ b/prepare-squads-release/action.yaml
@@ -69,7 +69,7 @@ runs:
 
     - name: Write program buffer
       id: write-program-buffer
-      uses: solana-developers/github-actions/write-program-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
+      uses: dev-jodee/github-actions/write-program-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
       with:
         program-id: ${{ inputs.program-id }}
         program: ${{ inputs.program }}
@@ -83,7 +83,7 @@ runs:
     - name: Write metadata buffer
       id: write-metadata-buffer
       if: inputs.metadata-path != ''
-      uses: solana-developers/github-actions/write-metadata-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
+      uses: dev-jodee/github-actions/write-metadata-buffer@b9f6b0d5be6d4f6a6cf7af373c5fd32416c8c896
       with:
         idl-path: ${{ inputs.metadata-path }}
         rpc-url: ${{ inputs.rpc-url }}

--- a/readme.md
+++ b/readme.md
@@ -96,8 +96,6 @@ Customize the workflow to your needs!
     - `keypair`: Deployer keypair
     - `buffer-authority-address`: Authority for the buffer
     - `priority-fee`: Transaction priority fee
-    - `extend-program`: Extend the program account before buffer creation if the new program is larger
-    - `transfer-authority-on-new-program`: Transfer buffer authority even when the target program account does not exist yet
 
 - `prepare-squads-release`: Creates release buffers for a Squads-controlled upgrade without creating a Squads proposal from CI
 
@@ -118,7 +116,6 @@ Customize the workflow to your needs!
     - `repo-url`: GitHub repository URL for the verify PDA transaction
     - `commit-hash`: Git commit hash for the verify PDA transaction
     - `mount-path`: Program directory path for the verify PDA transaction
-    - `extend-program`: Extend the program account before buffer creation if the new program is larger
 
 - `write-idl-buffer`: Writes an Anchor IDL buffer that will then later be set either from the provided keypair or from the squads multisig
   - Creates IDL buffer

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,6 @@ Customize the workflow to your needs!
     - `export-verify-pda`: Export a verify PDA transaction
     - `repo-url`: GitHub repository URL for the verify PDA transaction
     - `commit-hash`: Git commit hash for the verify PDA transaction
-    - `mount-path`: Program directory path for the verify PDA transaction
 
 - `write-idl-buffer`: Writes an Anchor IDL buffer that will then later be set either from the provided keypair or from the squads multisig
   - Creates IDL buffer

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ There are three examples:
 
 - [Anchor Program](https://github.com/Woody4618/anchor-github-action-example)
 - [Native Program](https://github.com/Woody4618/native-solana-github-action-example)
-- [Anchor Program using Squads](https://github.com/Woody4618/workflow-tutorial) 
+- [Anchor Program using Squads](https://github.com/Woody4618/workflow-tutorial)
 
 ### Required Secrets for specific actions
 
@@ -97,6 +97,23 @@ Customize the workflow to your needs!
     - `buffer-authority-address`: Authority for the buffer
     - `priority-fee`: Transaction priority fee
 
+- `prepare-squads-release`: Creates release buffers for a Squads-controlled upgrade without creating a Squads proposal from CI
+
+  - Creates the program buffer
+  - Transfers program buffer authority to the Squads vault
+  - Optionally creates a program-metadata buffer and transfers its authority to the Squads vault
+  - Optionally exports a `solana-verify` PDA transaction using the Squads vault as uploader
+  - Does not require the deployer keypair to be a Squads member
+  - Inputs:
+    - `program-id`: Target program ID
+    - `program`: Program name
+    - `rpc-url`: Solana RPC endpoint
+    - `keypair`: Payer keypair used for buffer preparation
+    - `squads-vault`: Squads vault to set as buffer authority
+    - `metadata-path`: Optional IDL or metadata JSON path
+    - `priority-fee`: Transaction priority fee
+    - `export-verify-pda`: Export a verify PDA transaction
+
 - `write-idl-buffer`: Writes an Anchor IDL buffer that will then later be set either from the provided keypair or from the squads multisig
   - Creates IDL buffer
   - Sets up IDL authority
@@ -113,6 +130,7 @@ Customize the workflow to your needs!
 These actions use the [program-metadata](https://github.com/solana-program/program-metadata) program to attach metadata (IDL, security.txt, etc.) to any Solana program. This is the newer alternative to Anchor's built-in IDL commands and supports any program, not just Anchor programs.
 
 - `metadata-upload`: Writes metadata directly to a program or from a pre-created buffer
+
   - Supports any seed type (idl, security, or custom)
   - Handles both direct upload and Squads multisig workflows
   - Can export transactions for Squads signing
@@ -147,6 +165,28 @@ These actions use the [program-metadata](https://github.com/solana-program/progr
 - `program-upgrade`: Handles the exteding of the program account in case the program is getting bigger and either sets the buffer or skips that in case of squads deploy
 - `idl-upload`: Either sets the Anchor IDL buffer or skips that in case of squads deploy
 - `verify-build`: Verifies on-chain programs match source using solana-verify andthe osec api
+
+### Squads buffer-only release
+
+For teams that do not want to add a CI-owned keypair as a Squads proposer, use `prepare-squads-release`. The keypair only pays for buffer preparation transactions. The resulting program buffer is owned by the Squads vault, and the upgrade proposal can be created manually in Squads.
+
+```yaml
+- name: Prepare Squads release buffers
+  uses: solana-developers/github-actions/prepare-squads-release@main
+  with:
+    program: ${{ env.PROGRAM }}
+    program-id: ${{ env.PROGRAM_ID }}
+    rpc-url: ${{ env.RPC_URL }}
+    keypair: ${{ secrets.MAINNET_DEPLOYER_KEYPAIR }}
+    squads-vault: ${{ secrets.MAINNET_MULTISIG_VAULT }}
+    metadata-path: ./target/idl/${{ env.PROGRAM }}.json
+    priority-fee: ${{ inputs.priority-fee }}
+    export-verify-pda: "true"
+    repo-url: ${{ github.server_url }}/${{ github.repository }}
+    commit-hash: ${{ github.sha }}
+```
+
+After the action completes, use the program buffer from the job summary when creating the program upgrade in Squads.
 
 ## 📝 Todo List
 

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,8 @@ Customize the workflow to your needs!
     - `keypair`: Deployer keypair
     - `buffer-authority-address`: Authority for the buffer
     - `priority-fee`: Transaction priority fee
+    - `extend-program`: Extend the program account before buffer creation if the new program is larger
+    - `transfer-authority-on-new-program`: Transfer buffer authority even when the target program account does not exist yet
 
 - `prepare-squads-release`: Creates release buffers for a Squads-controlled upgrade without creating a Squads proposal from CI
 
@@ -113,6 +115,10 @@ Customize the workflow to your needs!
     - `metadata-path`: Optional IDL or metadata JSON path
     - `priority-fee`: Transaction priority fee
     - `export-verify-pda`: Export a verify PDA transaction
+    - `repo-url`: GitHub repository URL for the verify PDA transaction
+    - `commit-hash`: Git commit hash for the verify PDA transaction
+    - `mount-path`: Program directory path for the verify PDA transaction
+    - `extend-program`: Extend the program account before buffer creation if the new program is larger
 
 - `write-idl-buffer`: Writes an Anchor IDL buffer that will then later be set either from the provided keypair or from the squads multisig
   - Creates IDL buffer

--- a/verify-build/action.yaml
+++ b/verify-build/action.yaml
@@ -58,7 +58,6 @@ runs:
         echo "Network: ${{ github.event.inputs.network }}"
         echo "Verify: ${{ github.event.inputs.verify }}"
         echo "Has keypair: ${{ inputs.keypair != '' }}"
-        echo "RPC URL: ${{ inputs.rpc-url }}"
 
     - name: Verify Build
       shell: bash

--- a/write-metadata-buffer/action.yaml
+++ b/write-metadata-buffer/action.yaml
@@ -50,9 +50,22 @@ runs:
 
           echo "$OUTPUT"
 
+          if echo "$OUTPUT" | grep -q "\[Error\]"; then
+            echo "Error: program-metadata create-buffer reported a failed transaction"
+            exit 1
+          fi
+
           BUFFER=$(echo "$OUTPUT" | grep -i "buffer:" | head -1 | grep -oE '[1-9A-HJ-NP-Za-km-z]{32,44}')
           if [ -z "$BUFFER" ]; then
             echo "Error: Could not extract buffer address from output"
+            exit 1
+          fi
+
+          if ! NO_COLOR=1 npx @solana-program/program-metadata@0.5.1 fetch-buffer "$BUFFER" \
+            --keypair ./deploy-keypair.json \
+            --rpc "${{ inputs.rpc-url }}" \
+            --raw >/dev/null 2>&1; then
+            echo "Error: Metadata buffer $BUFFER was not found after create-buffer"
             exit 1
           fi
 

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -28,10 +28,6 @@ inputs:
     description: "Maximum minutes to let a single write-buffer command run before printing diagnostics"
     required: false
     default: "55"
-  retry-timeout-minutes:
-    description: "Maximum minutes for each retry wrapper attempt"
-    required: false
-    default: "60"
   retry-attempts:
     description: "Maximum write-buffer attempts"
     required: false
@@ -65,9 +61,6 @@ runs:
         echo "Checking program info..."
         PROGRAM_INFO=$(solana program show ${{ inputs.program-id }} -u ${{ inputs.rpc-url }} 2>&1)
         EXIT_CODE=$?
-        echo "Raw program info output:"
-        echo "$PROGRAM_INFO"
-
         if [ $EXIT_CODE -eq 0 ]; then
           echo "exists=true" >> $GITHUB_OUTPUT
           echo "Program exists, checking size..."
@@ -122,7 +115,6 @@ runs:
 
         echo "Creating program buffer $BUFFER"
         echo "Deployer authority: $DEPLOYER"
-        echo "Program artifact: $PROGRAM_SO"
         echo "Program artifact size: $(wc -c < "$PROGRAM_SO") bytes"
         echo "Program artifact sha256: $(shasum -a 256 "$PROGRAM_SO" | awk '{print $1}')"
         echo "Max sign attempts: ${{ inputs.max-sign-attempts }}"

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -123,30 +123,48 @@ runs:
         echo "Program artifact sha256: $(shasum -a 256 "$PROGRAM_SO" | awk '{print $1}')"
         echo "Max sign attempts: ${{ inputs.max-sign-attempts }}"
         echo "Write timeout: ${{ inputs.write-timeout-minutes }} minutes"
+        echo "Write attempts: ${{ inputs.retry-attempts }}"
 
-        set +e
-        timeout "${{ inputs.write-timeout-minutes }}m" solana program write-buffer \
-          "$PROGRAM_SO" \
-          --url ${{ inputs.rpc-url }} \
-          --keypair ./deploy-keypair.json \
-          --buffer "$BUFFER_KEYPAIR" \
-          --max-sign-attempts ${{ inputs.max-sign-attempts }} \
-          --with-compute-unit-price ${{ inputs.priority-fee }} \
-          --use-rpc \
-          2>&1 | tee write-buffer.log
-        STATUS=${PIPESTATUS[0]}
-        set -e
+        ATTEMPT=1
+        STATUS=1
+        while [ "$ATTEMPT" -le "${{ inputs.retry-attempts }}" ]; do
+          WRITE_LOG="write-buffer-${ATTEMPT}.log"
+          echo "Starting write attempt $ATTEMPT of ${{ inputs.retry-attempts }} for buffer $BUFFER"
 
-        if [ "$STATUS" -ne 0 ]; then
+          set +e
+          timeout "${{ inputs.write-timeout-minutes }}m" solana program write-buffer \
+            "$PROGRAM_SO" \
+            --url ${{ inputs.rpc-url }} \
+            --keypair ./deploy-keypair.json \
+            --buffer "$BUFFER_KEYPAIR" \
+            --max-sign-attempts ${{ inputs.max-sign-attempts }} \
+            --with-compute-unit-price ${{ inputs.priority-fee }} \
+            --use-rpc \
+            2>&1 | tee "$WRITE_LOG"
+          STATUS=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$STATUS" -eq 0 ]; then
+            if ! grep -q "Buffer:" "$WRITE_LOG"; then
+              echo "Warning: solana CLI output did not include a Buffer line; using pre-generated buffer address"
+            fi
+
+            echo "Found buffer: $BUFFER"
+            echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
+            rm -f "$DUMPED_BUFFER"
+            exit 0
+          fi
+
           if [ "$STATUS" -eq 124 ]; then
-            echo "Error: Buffer creation timed out after ${{ inputs.write-timeout-minutes }} minutes"
+            echo "Error: Buffer write attempt $ATTEMPT timed out after ${{ inputs.write-timeout-minutes }} minutes"
           else
-            echo "Error: Buffer creation failed with exit code $STATUS"
+            echo "Error: Buffer write attempt $ATTEMPT failed with exit code $STATUS"
           fi
 
           echo "Buffer account: $BUFFER"
           echo "Checking whether the buffer was written despite the CLI exit status..."
 
+          rm -f "$DUMPED_BUFFER"
           if solana program dump "$BUFFER" "$DUMPED_BUFFER" -u ${{ inputs.rpc-url }}; then
             echo "Dumped buffer size: $(wc -c < "$DUMPED_BUFFER") bytes"
             echo "Dumped buffer sha256: $(shasum -a 256 "$DUMPED_BUFFER" | awk '{print $1}')"
@@ -163,20 +181,19 @@ runs:
             echo "Could not dump buffer $BUFFER"
           fi
 
+          if [ "$ATTEMPT" -lt "${{ inputs.retry-attempts }}" ]; then
+            echo "Retrying the same buffer so solana CLI can write only the missing chunks"
+            ATTEMPT=$((ATTEMPT + 1))
+            continue
+          fi
+
           echo "Recent transactions for buffer $BUFFER:"
           solana transaction-history "$BUFFER" -u ${{ inputs.rpc-url }} --limit 10 || true
           echo "Open buffers still owned by deployer $DEPLOYER:"
           solana program show --buffers --buffer-authority "$DEPLOYER" -u ${{ inputs.rpc-url }} || true
           rm -f "$DUMPED_BUFFER"
           exit "$STATUS"
-        fi
-
-        if ! grep -q "Buffer:" write-buffer.log; then
-          echo "Warning: solana CLI output did not include a Buffer line; using pre-generated buffer address"
-        fi
-
-        echo "Found buffer: $BUFFER"
-        echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
+        done
         rm -f "$DUMPED_BUFFER"
 
     # We can not set authority and upgrade program in the same instruction so it needs to be here

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -20,14 +20,6 @@ inputs:
     description: "Priority fee in microlamports"
     required: false
     default: "100000"
-  extend-program:
-    description: "Extend the program account before buffer creation if the new program is larger"
-    required: false
-    default: "true"
-  transfer-authority-on-new-program:
-    description: "Transfer buffer authority even when the target program account does not exist yet"
-    required: false
-    default: "false"
 
 outputs:
   buffer:
@@ -75,7 +67,7 @@ runs:
         set -e  # Restore error checking
 
     - name: Resize program if needed
-      if: inputs.extend-program == 'true' && steps.check-program.outputs.exists == 'true'
+      if: steps.check-program.outputs.exists == 'true'
       shell: bash
       run: |
         REQUIRED_SIZE=$(wc -c < ./target/deploy/${{ inputs.program }}.so)
@@ -135,7 +127,7 @@ runs:
     # The rent for the buffer will be returned to the local keypair though once the program gets deployed in squads. So its fine.
     # If the deploy fails you can also close the buffer with the multisig using the cli command squad-closebuffer
     - name: Transfer buffer authority
-      if: steps.write-buffer.outputs.buffer != '' && (steps.check-program.outputs.exists == 'true' || inputs.transfer-authority-on-new-program == 'true')
+      if: steps.check-program.outputs.exists == 'true'
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -20,6 +20,22 @@ inputs:
     description: "Priority fee in microlamports"
     required: false
     default: "100000"
+  max-sign-attempts:
+    description: "Maximum Solana CLI signing attempts for write-buffer"
+    required: false
+    default: "100"
+  write-timeout-minutes:
+    description: "Maximum minutes to let a single write-buffer command run before printing diagnostics"
+    required: false
+    default: "55"
+  retry-timeout-minutes:
+    description: "Maximum minutes for each retry wrapper attempt"
+    required: false
+    default: "60"
+  retry-attempts:
+    description: "Maximum write-buffer attempts"
+    required: false
+    default: "3"
 
 outputs:
   buffer:
@@ -90,34 +106,52 @@ runs:
       id: write-buffer
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
-        timeout_minutes: 60
-        max_attempts: 3
+        timeout_minutes: ${{ inputs.retry-timeout-minutes }}
+        max_attempts: ${{ inputs.retry-attempts }}
         shell: bash
         command: |
-          echo "Creating program buffer... (Attempt $RETRY_ATTEMPT of 3)"
-          OUTPUT=$(solana program write-buffer \
+          set -o pipefail
+
+          BUFFER_KEYPAIR=$(mktemp ./buffer-keypair.XXXXXX.json)
+          rm -f "$BUFFER_KEYPAIR"
+          solana-keygen new --no-bip39-passphrase --silent --outfile "$BUFFER_KEYPAIR"
+          BUFFER=$(solana-keygen pubkey "$BUFFER_KEYPAIR")
+          DEPLOYER=$(solana-keygen pubkey ./deploy-keypair.json)
+
+          echo "Creating program buffer $BUFFER"
+          echo "Deployer authority: $DEPLOYER"
+          echo "Max sign attempts: ${{ inputs.max-sign-attempts }}"
+          echo "Write timeout: ${{ inputs.write-timeout-minutes }} minutes"
+
+          set +e
+          timeout "${{ inputs.write-timeout-minutes }}m" solana program write-buffer \
             ./target/deploy/${{ inputs.program }}.so \
             --url ${{ inputs.rpc-url }} \
             --keypair ./deploy-keypair.json \
-            --max-sign-attempts 100 \
+            --buffer "$BUFFER_KEYPAIR" \
+            --max-sign-attempts ${{ inputs.max-sign-attempts }} \
             --with-compute-unit-price ${{ inputs.priority-fee }} \
             --use-rpc \
-            2>&1)
+            2>&1 | tee write-buffer.log
+          STATUS=${PIPESTATUS[0]}
+          set -e
 
-          # Print output in real-time
-          echo "$OUTPUT"
-
-          # Check for success
-          if ! echo "$OUTPUT" | grep -q "Buffer:"; then
-            echo "Error: Buffer creation failed"
-            exit 1
+          if [ "$STATUS" -eq 124 ]; then
+            echo "Error: Buffer creation timed out after ${{ inputs.write-timeout-minutes }} minutes"
           fi
 
-          # Extract buffer if successful
-          BUFFER=$(echo "$OUTPUT" | grep "Buffer:" | cut -d " " -f2)
-          if [ -z "$BUFFER" ]; then
-            echo "Error: Could not extract buffer address"
-            exit 1
+          if [ "$STATUS" -ne 0 ]; then
+            echo "Error: Buffer creation failed with exit code $STATUS"
+            echo "Buffer account: $BUFFER"
+            echo "Recent transactions for buffer $BUFFER:"
+            solana transaction-history "$BUFFER" -u ${{ inputs.rpc-url }} --limit 10 || true
+            echo "Open buffers still owned by deployer $DEPLOYER:"
+            solana program show --buffers --buffer-authority "$DEPLOYER" -u ${{ inputs.rpc-url }} || true
+            exit "$STATUS"
+          fi
+
+          if ! grep -q "Buffer:" write-buffer.log; then
+            echo "Warning: solana CLI output did not include a Buffer line; using pre-generated buffer address"
           fi
 
           echo "Found buffer: $BUFFER"
@@ -147,3 +181,4 @@ runs:
       run: |
         rm -f ./deploy-keypair.json
         rm -f ./authority-keypair.json
+        rm -f ./buffer-keypair.*.json

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -20,6 +20,14 @@ inputs:
     description: "Priority fee in microlamports"
     required: false
     default: "100000"
+  extend-program:
+    description: "Extend the program account before buffer creation if the new program is larger"
+    required: false
+    default: "true"
+  transfer-authority-on-new-program:
+    description: "Transfer buffer authority even when the target program account does not exist yet"
+    required: false
+    default: "false"
 
 outputs:
   buffer:
@@ -67,7 +75,7 @@ runs:
         set -e  # Restore error checking
 
     - name: Resize program if needed
-      if: steps.check-program.outputs.exists == 'true'
+      if: inputs.extend-program == 'true' && steps.check-program.outputs.exists == 'true'
       shell: bash
       run: |
         REQUIRED_SIZE=$(wc -c < ./target/deploy/${{ inputs.program }}.so)
@@ -127,7 +135,7 @@ runs:
     # The rent for the buffer will be returned to the local keypair though once the program gets deployed in squads. So its fine.
     # If the deploy fails you can also close the buffer with the multisig using the cli command squad-closebuffer
     - name: Transfer buffer authority
-      if: steps.check-program.outputs.exists == 'true'
+      if: steps.write-buffer.outputs.buffer != '' && (steps.check-program.outputs.exists == 'true' || inputs.transfer-authority-on-new-program == 'true')
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -36,6 +36,10 @@ inputs:
     description: "Maximum write-buffer attempts"
     required: false
     default: "3"
+  use-rpc:
+    description: "Send write transactions through the configured RPC instead of validator TPUs"
+    required: false
+    default: "true"
 
 outputs:
   buffer:
@@ -124,6 +128,12 @@ runs:
         echo "Max sign attempts: ${{ inputs.max-sign-attempts }}"
         echo "Write timeout: ${{ inputs.write-timeout-minutes }} minutes"
         echo "Write attempts: ${{ inputs.retry-attempts }}"
+        echo "Use RPC transport: ${{ inputs.use-rpc }}"
+
+        USE_RPC_ARGS=()
+        if [ "${{ inputs.use-rpc }}" = "true" ]; then
+          USE_RPC_ARGS=(--use-rpc)
+        fi
 
         ATTEMPT=1
         STATUS=1
@@ -139,7 +149,7 @@ runs:
             --buffer "$BUFFER_KEYPAIR" \
             --max-sign-attempts ${{ inputs.max-sign-attempts }} \
             --with-compute-unit-price ${{ inputs.priority-fee }} \
-            --use-rpc \
+            "${USE_RPC_ARGS[@]}" \
             2>&1 | tee "$WRITE_LOG"
           STATUS=${PIPESTATUS[0]}
           set -e

--- a/write-program-buffer/action.yaml
+++ b/write-program-buffer/action.yaml
@@ -104,58 +104,80 @@ runs:
 
     - name: Write program buffer
       id: write-buffer
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-      with:
-        timeout_minutes: ${{ inputs.retry-timeout-minutes }}
-        max_attempts: ${{ inputs.retry-attempts }}
-        shell: bash
-        command: |
-          set -o pipefail
+      shell: bash
+      run: |
+        set -euo pipefail
 
-          BUFFER_KEYPAIR=$(mktemp ./buffer-keypair.XXXXXX.json)
-          rm -f "$BUFFER_KEYPAIR"
-          solana-keygen new --no-bip39-passphrase --silent --outfile "$BUFFER_KEYPAIR"
-          BUFFER=$(solana-keygen pubkey "$BUFFER_KEYPAIR")
-          DEPLOYER=$(solana-keygen pubkey ./deploy-keypair.json)
+        PROGRAM_SO="./target/deploy/${{ inputs.program }}.so"
+        BUFFER_KEYPAIR=$(mktemp ./buffer-keypair.XXXXXX.json)
+        rm -f "$BUFFER_KEYPAIR"
+        solana-keygen new --no-bip39-passphrase --silent --outfile "$BUFFER_KEYPAIR"
+        BUFFER=$(solana-keygen pubkey "$BUFFER_KEYPAIR")
+        DEPLOYER=$(solana-keygen pubkey ./deploy-keypair.json)
+        DUMPED_BUFFER=$(mktemp ./buffer-dump.XXXXXX.so)
 
-          echo "Creating program buffer $BUFFER"
-          echo "Deployer authority: $DEPLOYER"
-          echo "Max sign attempts: ${{ inputs.max-sign-attempts }}"
-          echo "Write timeout: ${{ inputs.write-timeout-minutes }} minutes"
+        echo "Creating program buffer $BUFFER"
+        echo "Deployer authority: $DEPLOYER"
+        echo "Program artifact: $PROGRAM_SO"
+        echo "Program artifact size: $(wc -c < "$PROGRAM_SO") bytes"
+        echo "Program artifact sha256: $(shasum -a 256 "$PROGRAM_SO" | awk '{print $1}')"
+        echo "Max sign attempts: ${{ inputs.max-sign-attempts }}"
+        echo "Write timeout: ${{ inputs.write-timeout-minutes }} minutes"
 
-          set +e
-          timeout "${{ inputs.write-timeout-minutes }}m" solana program write-buffer \
-            ./target/deploy/${{ inputs.program }}.so \
-            --url ${{ inputs.rpc-url }} \
-            --keypair ./deploy-keypair.json \
-            --buffer "$BUFFER_KEYPAIR" \
-            --max-sign-attempts ${{ inputs.max-sign-attempts }} \
-            --with-compute-unit-price ${{ inputs.priority-fee }} \
-            --use-rpc \
-            2>&1 | tee write-buffer.log
-          STATUS=${PIPESTATUS[0]}
-          set -e
+        set +e
+        timeout "${{ inputs.write-timeout-minutes }}m" solana program write-buffer \
+          "$PROGRAM_SO" \
+          --url ${{ inputs.rpc-url }} \
+          --keypair ./deploy-keypair.json \
+          --buffer "$BUFFER_KEYPAIR" \
+          --max-sign-attempts ${{ inputs.max-sign-attempts }} \
+          --with-compute-unit-price ${{ inputs.priority-fee }} \
+          --use-rpc \
+          2>&1 | tee write-buffer.log
+        STATUS=${PIPESTATUS[0]}
+        set -e
 
+        if [ "$STATUS" -ne 0 ]; then
           if [ "$STATUS" -eq 124 ]; then
             echo "Error: Buffer creation timed out after ${{ inputs.write-timeout-minutes }} minutes"
-          fi
-
-          if [ "$STATUS" -ne 0 ]; then
+          else
             echo "Error: Buffer creation failed with exit code $STATUS"
-            echo "Buffer account: $BUFFER"
-            echo "Recent transactions for buffer $BUFFER:"
-            solana transaction-history "$BUFFER" -u ${{ inputs.rpc-url }} --limit 10 || true
-            echo "Open buffers still owned by deployer $DEPLOYER:"
-            solana program show --buffers --buffer-authority "$DEPLOYER" -u ${{ inputs.rpc-url }} || true
-            exit "$STATUS"
           fi
 
-          if ! grep -q "Buffer:" write-buffer.log; then
-            echo "Warning: solana CLI output did not include a Buffer line; using pre-generated buffer address"
+          echo "Buffer account: $BUFFER"
+          echo "Checking whether the buffer was written despite the CLI exit status..."
+
+          if solana program dump "$BUFFER" "$DUMPED_BUFFER" -u ${{ inputs.rpc-url }}; then
+            echo "Dumped buffer size: $(wc -c < "$DUMPED_BUFFER") bytes"
+            echo "Dumped buffer sha256: $(shasum -a 256 "$DUMPED_BUFFER" | awk '{print $1}')"
+
+            if cmp -s "$PROGRAM_SO" "$DUMPED_BUFFER"; then
+              echo "Buffer contents match the program artifact; continuing with buffer $BUFFER"
+              echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
+              rm -f "$DUMPED_BUFFER"
+              exit 0
+            fi
+
+            echo "Dumped buffer does not match the program artifact"
+          else
+            echo "Could not dump buffer $BUFFER"
           fi
 
-          echo "Found buffer: $BUFFER"
-          echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
+          echo "Recent transactions for buffer $BUFFER:"
+          solana transaction-history "$BUFFER" -u ${{ inputs.rpc-url }} --limit 10 || true
+          echo "Open buffers still owned by deployer $DEPLOYER:"
+          solana program show --buffers --buffer-authority "$DEPLOYER" -u ${{ inputs.rpc-url }} || true
+          rm -f "$DUMPED_BUFFER"
+          exit "$STATUS"
+        fi
+
+        if ! grep -q "Buffer:" write-buffer.log; then
+          echo "Warning: solana CLI output did not include a Buffer line; using pre-generated buffer address"
+        fi
+
+        echo "Found buffer: $BUFFER"
+        echo "buffer=$BUFFER" >> $GITHUB_OUTPUT
+        rm -f "$DUMPED_BUFFER"
 
     # We can not set authority and upgrade program in the same instruction so it needs to be here
     # The rent for the buffer will be returned to the local keypair though once the program gets deployed in squads. So its fine.


### PR DESCRIPTION
## Summary
- Add a prepare-squads-release composite action for buffer-only Squads releases.
- Transfer program and optional program-metadata buffer authority to the Squads vault without creating a proposal from CI.
- Document the new flow for teams that do not want to add a CI key as a Squads proposer.
