### PR TITLE
feat(npm-publish): add npm publish action

### DIFF
--- a/npm-publish/action.yaml
+++ b/npm-publish/action.yaml
@@ -1,0 +1,229 @@
+name: "NPM Publish"
+description: "Publishes one TypeScript package to npm with pnpm using Trusted Publishing"
+inputs:
+  package:
+    description: "Package name to publish. Used for registry checks. Leave empty to infer from the package manifest."
+    required: false
+    default: ""
+  package-directory:
+    description: "Directory containing the built package manifest to pack and publish."
+    required: false
+    default: "."
+  node-version:
+    description: "Node.js version to install."
+    required: false
+    default: "lts/*"
+  pnpm-version:
+    description: "pnpm version to install. Leave empty to use the packageManager field."
+    required: false
+    default: ""
+  tag:
+    description: "npm dist-tag to publish under. Leave empty to use latest, or beta for prerelease versions."
+    required: false
+    default: ""
+  dry-run:
+    description: "Run publish validation without publishing to npm."
+    required: false
+    default: "false"
+  check-version-available:
+    description: "Fail early when this package version already exists on npm."
+    required: false
+    default: "true"
+  skip-existing:
+    description: "Skip publishing successfully when this package version already exists on npm."
+    required: false
+    default: "false"
+outputs:
+  package:
+    description: "Published package name."
+    value: ${{ steps.package.outputs.package }}
+  version:
+    description: "Published package version."
+    value: ${{ steps.package.outputs.version }}
+  tag:
+    description: "npm dist-tag used for publishing."
+    value: ${{ steps.package.outputs.tag }}
+  published:
+    description: "Whether the action published to npm."
+    value: ${{ steps.status.outputs.published }}
+  already-published:
+    description: "Whether this package version already existed on npm."
+    value: ${{ steps.version_exists.outputs.exists }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
+
+    - name: Install Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: "https://registry.npmjs.org"
+
+    - name: Show tool versions
+      shell: bash
+      run: |
+        node --version
+        pnpm --version
+        npm --version
+
+    - name: Resolve package and version
+      id: package
+      shell: bash
+      working-directory: ${{ inputs.package-directory }}
+      env:
+        PACKAGE_INPUT: ${{ inputs.package }}
+        TAG_INPUT: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -f package.json ]; then
+          echo "::error::No package.json found in ${{ inputs.package-directory }}."
+          exit 1
+        fi
+
+        PACKAGE="$PACKAGE_INPUT"
+        if [ -z "$PACKAGE" ]; then
+          PACKAGE="$(node -p "require('./package.json').name || ''")"
+        fi
+        VERSION="$(node -p "require('./package.json').version || ''")"
+
+        if [ -z "$PACKAGE" ] || [ -z "$VERSION" ]; then
+          echo "::error::Could not resolve package name and version from package.json."
+          exit 1
+        fi
+
+        TAG="$TAG_INPUT"
+        if [ -z "$TAG" ]; then
+          case "$VERSION" in
+            *-*) TAG="beta" ;;
+            *) TAG="latest" ;;
+          esac
+        fi
+
+        echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "Publishing target: $PACKAGE@$VERSION (tag: $TAG)"
+
+    - name: Pack tarball
+      id: pack
+      shell: bash
+      working-directory: ${{ inputs.package-directory }}
+      run: |
+        set -euo pipefail
+
+        PACK_DIR="${RUNNER_TEMP:-/tmp}/npm-pack"
+        rm -rf "$PACK_DIR"
+        mkdir -p "$PACK_DIR"
+
+        TARBALL="$(pnpm pack --pack-destination "$PACK_DIR" | tail -n 1)"
+        if [ ! -f "$TARBALL" ]; then
+          echo "::error::pnpm pack did not produce a tarball."
+          exit 1
+        fi
+
+        echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+        echo "Packed: $TARBALL"
+
+    - name: Validate tarball
+      shell: bash
+      env:
+        TARBALL: ${{ steps.pack.outputs.tarball }}
+      run: |
+        set -euo pipefail
+
+        if tar -xzOf "$TARBALL" package/package.json | grep -q '"workspace:'; then
+          echo "::error::Tarball contains unresolved workspace: protocol dependencies."
+          exit 1
+        fi
+
+        if ! tar -tzf "$TARBALL" | grep -q '^package/dist/'; then
+          echo "::error::Tarball does not contain any dist/ build artifacts."
+          exit 1
+        fi
+
+    - name: Check npm version availability
+      id: version_exists
+      shell: bash
+      env:
+        CHECK_VERSION_AVAILABLE: ${{ inputs.check-version-available }}
+        PACKAGE: ${{ steps.package.outputs.package }}
+        SKIP_EXISTING: ${{ inputs.skip-existing }}
+        VERSION: ${{ steps.package.outputs.version }}
+      run: |
+        set -euo pipefail
+
+        if [ "$CHECK_VERSION_AVAILABLE" != "true" ] && [ "$SKIP_EXISTING" != "true" ]; then
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if npm view "$PACKAGE@$VERSION" version >/dev/null 2>&1; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          if [ "$SKIP_EXISTING" = "true" ]; then
+            echo "$PACKAGE@$VERSION already exists on npm; skipping publish."
+            exit 0
+          fi
+
+          echo "::error::$PACKAGE@$VERSION already exists on npm. Bump the package version before publishing."
+          exit 1
+        fi
+
+        echo "exists=false" >> "$GITHUB_OUTPUT"
+
+    - name: Ensure npm supports trusted publishing
+      if: inputs.dry-run != 'true' && steps.version_exists.outputs.exists != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        REQUIRED="11.5.1"
+        CURRENT="$(npm --version)"
+        LOWEST="$(printf '%s\n%s\n' "$REQUIRED" "$CURRENT" | sort -V | head -n 1)"
+
+        if [ "$LOWEST" != "$REQUIRED" ]; then
+          echo "npm $CURRENT predates trusted publishing support; installing npm@^11.5.1."
+          npm install -g "npm@^11.5.1"
+          npm --version
+        fi
+
+    - name: Publish to npm
+      if: steps.version_exists.outputs.exists != 'true'
+      shell: bash
+      working-directory: ${{ inputs.package-directory }}
+      env:
+        DRY_RUN: ${{ inputs.dry-run }}
+        NPM_CONFIG_PROVENANCE: "true"
+        TAG: ${{ steps.package.outputs.tag }}
+        TARBALL: ${{ steps.pack.outputs.tarball }}
+      run: |
+        set -euo pipefail
+
+        PUBLISH_ARGS=("$TARBALL" --access public --tag "$TAG")
+        if [ "$DRY_RUN" = "true" ]; then
+          export NPM_CONFIG_PROVENANCE=false
+          PUBLISH_ARGS+=(--dry-run)
+        fi
+
+        npm publish "${PUBLISH_ARGS[@]}"
+
+    - name: Set publish status
+      id: status
+      shell: bash
+      env:
+        DRY_RUN: ${{ inputs.dry-run }}
+        VERSION_EXISTS: ${{ steps.version_exists.outputs.exists }}
+      run: |
+        set -euo pipefail
+
+        if [ "$DRY_RUN" = "true" ] || [ "$VERSION_EXISTS" = "true" ]; then
+          echo "published=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "published=true" >> "$GITHUB_OUTPUT"
+        fi

--- a/npm-publish/action.yaml
+++ b/npm-publish/action.yaml
@@ -138,12 +138,14 @@ runs:
       run: |
         set -euo pipefail
 
-        if tar -xzOf "$TARBALL" package/package.json | grep -q '"workspace:'; then
+        MANIFEST="$(tar -xzOf "$TARBALL" package/package.json)"
+        if grep -q '"workspace:' <<< "$MANIFEST"; then
           echo "::error::Tarball contains unresolved workspace: protocol dependencies."
           exit 1
         fi
 
-        if ! tar -tzf "$TARBALL" | grep -q '^package/dist/'; then
+        CONTENTS="$(tar -tzf "$TARBALL")"
+        if ! grep -q '^package/dist/' <<< "$CONTENTS"; then
           echo "::error::Tarball does not contain any dist/ build artifacts."
           exit 1
         fi

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,83 @@ Generated client:
     skip-existing: "true"
 ```
 
+### NPM Publishing
+
+- `npm-publish`: Publishes one TypeScript package to npm with pnpm using Trusted Publishing
+  - Uses GitHub OIDC and npm provenance, with no `NODE_AUTH_TOKEN`
+  - Packs and validates the tarball, then publishes the built package
+  - Resolves the npm dist-tag automatically (`beta` for prerelease versions, otherwise `latest`)
+  - Optionally checks whether the package version already exists on npm
+  - Leaves checkout, install, build, tests, generated clients, tags, and GitHub releases to the caller workflow
+  - Inputs:
+    - `package`: Package name to publish, or empty to infer from the package manifest
+    - `package-directory`: Directory containing the built package manifest to pack and publish
+    - `node-version`: Node.js version to install
+    - `pnpm-version`: pnpm version to install, or empty to use the `packageManager` field
+    - `tag`: npm dist-tag to publish under, or empty to resolve automatically
+    - `dry-run`: Validate without publishing to npm
+    - `check-version-available`: Fail early when this package version already exists on npm
+    - `skip-existing`: Skip publishing successfully when this package version already exists on npm
+  - Outputs:
+    - `package`: Published package name
+    - `version`: Published package version
+    - `tag`: npm dist-tag used for publishing
+    - `published`: Whether the action published to npm
+    - `already-published`: Whether this package version already existed on npm
+
+Caller workflows must grant OIDC token access and configure Trusted Publishing for the package on npm. The Trusted Publisher configuration should match the caller repository and workflow file, not this shared action repository:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+Trusted Publishing requires npm 11.5.1 or newer. The action upgrades npm when the installed version is older, so `node-version: lts/*` works without a token.
+
+Pin this action to a released tag or commit SHA instead of `main`.
+
+The caller installs dependencies and builds the package before invoking the action.
+
+Single package:
+
+```yaml
+- uses: actions/checkout@v6
+
+- uses: pnpm/action-setup@v6
+
+- run: pnpm install --frozen-lockfile
+
+- name: Build package
+  run: pnpm --filter "@scope/my-package" build
+
+- uses: solana-developers/github-actions/npm-publish@<release-tag-or-commit-sha>
+  with:
+    package: "@scope/my-package"
+    package-directory: clients/typescript
+```
+
+Generated client:
+
+```yaml
+- uses: actions/checkout@v6
+
+- uses: pnpm/action-setup@v6
+
+- run: pnpm install --frozen-lockfile
+
+- run: pnpm run generate-clients
+
+- name: Build generated client
+  run: pnpm --filter "@scope/my-client" build
+
+- uses: solana-developers/github-actions/npm-publish@<release-tag-or-commit-sha>
+  with:
+    package: "@scope/my-client"
+    package-directory: clients/typescript
+    skip-existing: "true"
+```
+
 ### Deployment
 
 - `write-program-buffer`: Writes a buffer that will then later be set either from the provided keypair or from the squads multisig


### PR DESCRIPTION
## Summary
- Add `npm-publish` composite action: publishes one built TypeScript package to npm with pnpm using Trusted Publishing
- The caller installs deps and builds; the action resolves the npm dist-tag from the version (`beta` for prereleases, else `latest`), packs, and validates the tarball (rejects unresolved `workspace:` deps and missing `dist/` artifacts)
- Checks npm for an existing version (`check-version-available` / `skip-existing`) and ensures npm >= 11.5.1 so tokenless OIDC trusted publishing works on `node-version: lts/*`
- Publishes with provenance, supports `--dry-run`, and exposes `package` / `version` / `tag` / `published` / `already-published` outputs
- Document the action in `readme.md`

## Test Plan
- YAML parses; dist-tag detection, npm version gate, and tarball validation verified locally
- Full end-to-end run requires a GitHub runner and a Trusted Publisher configured for the target package on npm